### PR TITLE
Feat: 로그인 확인, 로그아웃

### DIFF
--- a/src/api/query/userQuery.ts
+++ b/src/api/query/userQuery.ts
@@ -31,6 +31,6 @@ export const useLogOut = () => {
   });
 };
 
-export const useIsLogined = () => {
-  return useQuery([USER_KEY], () => UserService.isLogined());
+export const useIsLogin = () => {
+  return useQuery([USER_KEY], () => UserService.isLogin());
 };

--- a/src/api/query/userQuery.ts
+++ b/src/api/query/userQuery.ts
@@ -22,7 +22,7 @@ export const useLogOut = () => {
   const queryClient = useQueryClient();
   return useMutation([USER_KEY], () => UserService.logOut(), {
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries([USER_KEY]);
       alert('Success');
     },
     onError: () => {

--- a/src/api/query/userQuery.ts
+++ b/src/api/query/userQuery.ts
@@ -1,4 +1,4 @@
-import { useMutation } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { UserService } from '../service';
 import { useLink } from '@/hooks';
 
@@ -16,4 +16,21 @@ export const useSignUp = (name: string, gender: string, birthday: string, countr
       link.to('home');
     },
   });
+};
+
+export const useLogOut = () => {
+  const queryClient = useQueryClient();
+  return useMutation([USER_KEY], () => UserService.logOut(), {
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+      alert('Success');
+    },
+    onError: () => {
+      alert('Error');
+    },
+  });
+};
+
+export const useIsLogined = () => {
+  return useQuery([USER_KEY], () => UserService.isLogined());
 };

--- a/src/api/service/UserService.ts
+++ b/src/api/service/UserService.ts
@@ -22,7 +22,7 @@ class UserService extends HTTPInterface {
       .catch(HTTPInterface._handleError);
   }
 
-  public isLogined(): Promise<{ isLogined: boolean }> {
+  public isLogin(): Promise<{ isLogin: boolean }> {
     return this.baseHTTP
       .get('islogined')
       .then(HTTPInterface._handleResponse)

--- a/src/api/service/UserService.ts
+++ b/src/api/service/UserService.ts
@@ -14,6 +14,20 @@ class UserService extends HTTPInterface {
       .then(HTTPInterface._handleResponse)
       .catch(HTTPInterface._handleError);
   }
+
+  public logOut(): Promise<{ message: string }[]> {
+    return this.baseHTTP
+      .post('logout')
+      .then(HTTPInterface._handleResponse)
+      .catch(HTTPInterface._handleError);
+  }
+
+  public isLogined(): Promise<{ isLogined: boolean }> {
+    return this.baseHTTP
+      .get('islogined')
+      .then(HTTPInterface._handleResponse)
+      .catch(HTTPInterface._handleError);
+  }
 }
 
 const userService = new UserService();

--- a/src/components/baumann/BaumannLONGSTRINGType.tsx
+++ b/src/components/baumann/BaumannLONGSTRINGType.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import { CircleCheckBox, Flex, Text } from '..';
+import Text from '../common/Text';
+import { CircleCheckBox, Flex } from '..';
 import type { BaumannQNA, BaumannQuestion } from '@/types/baumann';
 
 interface Props {
@@ -63,7 +64,7 @@ const AnswerItem = styled(Flex)<StyleAnswerProps>`
   }
 `;
 
-const StyledText = styled(Text ?? 'div')`
+const StyledText = styled(Text)`
   white-space: pre-line;
 
   span {

--- a/src/components/baumann/BaumannLONGSTRINGType.tsx
+++ b/src/components/baumann/BaumannLONGSTRINGType.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import { CircleCheckBox, Flex, Text } from '..';
 import type { BaumannQNA, BaumannQuestion } from '@/types/baumann';
-import { CircleCheckBox, Flex, Text } from '@/components';
 
 interface Props {
   baumann: {
@@ -63,7 +63,7 @@ const AnswerItem = styled(Flex)<StyleAnswerProps>`
   }
 `;
 
-const StyledText = styled(Text)`
+const StyledText = styled(Text ?? 'div')`
   white-space: pre-line;
 
   span {

--- a/src/components/baumann/BaumannPLAINType.tsx
+++ b/src/components/baumann/BaumannPLAINType.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import type { BaumannQNA, BaumannQuestion } from '@/types/baumann';
-import { Flex, SkeletonImage, Text } from '..';
+import { Flex } from '../styled';
+import Text from '../common/Text';
+import { SkeletonImage } from '../common';
 import FrequencyBar from './FrequencyBar';
+import type { BaumannQNA, BaumannQuestion } from '@/types/baumann';
 
 interface Props {
   baumann: {
@@ -45,7 +47,7 @@ const StyledFlex = styled(Flex)`
   padding-bottom: 60px;
 `;
 
-const StyledText = styled(Text ?? 'div')`
+const StyledText = styled(Text)`
   white-space: pre-line;
 
   span {

--- a/src/components/baumann/BaumannPLAINType.tsx
+++ b/src/components/baumann/BaumannPLAINType.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import type { BaumannQNA, BaumannQuestion } from '@/types/baumann';
-import { Flex, SkeletonImage, Text } from '@/components';
+import { Flex, SkeletonImage, Text } from '..';
 import FrequencyBar from './FrequencyBar';
 
 interface Props {
@@ -45,7 +45,7 @@ const StyledFlex = styled(Flex)`
   padding-bottom: 60px;
 `;
 
-const StyledText = styled(Text)`
+const StyledText = styled(Text ?? 'div')`
   white-space: pre-line;
 
   span {

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,6 +1,6 @@
+export { default as Text } from './Text';
 export { default as Tag } from './Tag';
 export { default as Icon } from './Icon';
-export { default as Text } from './Text';
 export { default as Button } from './Button';
 export { default as Header } from './Header';
 export { default as SelectOption } from './SelectOption';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -5,5 +5,6 @@ export { default as Button } from './Button';
 export { default as Header } from './Header';
 export { default as SelectOption } from './SelectOption';
 export { default as SkeletonImage } from './SkeletonImage';
+export { default as ProgressBar } from './ProgressBar';
 export { default as CircleCheckBox } from './CircleCheckBox';
 export { default as GenderInputBox } from './GenderInputBox';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,9 +1,9 @@
 export * from './icons';
 export * from './styled';
 export * from './common';
-export * from './modal';
 export * from './baumann';
 export * from './product';
+export * from './modal';
 
 export { default as Title } from './Title';
 export { default as SearchBar } from './SearchBar';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,10 +1,10 @@
-export * from './styled';
-export * from './common';
 export * from './icons';
 export * from './styled';
+export * from './common';
+export * from './modal';
 export * from './baumann';
 export * from './product';
-export * from './modal';
+
 export { default as Title } from './Title';
 export { default as SearchBar } from './SearchBar';
 export { default as LandingScrollText } from './LandingScrollText';

--- a/src/components/modal/HeaderModal.tsx
+++ b/src/components/modal/HeaderModal.tsx
@@ -4,9 +4,21 @@ import { Flex } from '../styled';
 import { Button, Text } from '../common';
 import useLink from '@/hooks/useLink';
 import { STATIC_NAVIGATION } from '@/constants';
+import { useIsLogined, useLogOut } from '@/api/query/userQuery';
+import React from 'react';
 
 function HeaderModal() {
   const link = useLink();
+  const { data } = useIsLogined();
+  const logOut = useLogOut();
+
+  const handleClickBottomButton = React.useCallback(() => {
+    if (data?.isLogined) {
+      logOut.mutate();
+    } else {
+      link.to('login');
+    }
+  }, [data, link, logOut]);
 
   return (
     <Wrapper flexDirection="column" justifyContent="space-between">
@@ -22,8 +34,8 @@ function HeaderModal() {
           </Text>
         ))}
       </FlexWithLine>
-      <Button variant="filled" hierarchy="primary" onClick={() => link.to('login')}>
-        LOGIN
+      <Button variant="filled" hierarchy="primary" onClick={handleClickBottomButton}>
+        {data?.isLogined ? 'LOGOUT' : 'LOGIN'}
       </Button>
     </Wrapper>
   );

--- a/src/components/modal/HeaderModal.tsx
+++ b/src/components/modal/HeaderModal.tsx
@@ -4,16 +4,16 @@ import { Flex } from '../styled';
 import { Button, Text } from '../common';
 import useLink from '@/hooks/useLink';
 import { STATIC_NAVIGATION } from '@/constants';
-import { useIsLogined, useLogOut } from '@/api/query/userQuery';
+import { useIsLogin, useLogOut } from '@/api/query/userQuery';
 import React from 'react';
 
 function HeaderModal() {
   const link = useLink();
-  const { data } = useIsLogined();
+  const { data } = useIsLogin();
   const logOut = useLogOut();
 
   const handleClickBottomButton = React.useCallback(() => {
-    if (data?.isLogined) {
+    if (data?.isLogin) {
       logOut.mutate();
     } else {
       link.to('login');
@@ -35,7 +35,7 @@ function HeaderModal() {
         ))}
       </FlexWithLine>
       <Button variant="filled" hierarchy="primary" onClick={handleClickBottomButton}>
-        {data?.isLogined ? 'LOGOUT' : 'LOGIN'}
+        {data?.isLogin ? 'LOGOUT' : 'LOGIN'}
       </Button>
     </Wrapper>
   );

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
 
-import { Flex } from '@/components/styled';
+import { Flex } from '../styled';
+import { Icon, SkeletonImage, Text } from '../common';
 import type { ProductInList } from '@/types/product';
-import { Icon, SkeletonImage, Text } from '@/components';
 
 interface Props {
   product: ProductInList;

--- a/src/pages/admin/baumann.tsx
+++ b/src/pages/admin/baumann.tsx
@@ -219,6 +219,9 @@ export const getServerSideProps: GetServerSideProps<Props> = async (context) => 
     };
   } catch (error) {
     return {
+      props: {
+        baumanns: [],
+      },
       redirect: {
         permanent: false,
         destination: '/',

--- a/src/pages/ocr/index.tsx
+++ b/src/pages/ocr/index.tsx
@@ -16,38 +16,41 @@ export default function OCRPage() {
   const [imageUrl, setImageUrl] = React.useState<string>('');
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
 
-  const handleChangeFile = React.useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (files && files.length > 0) {
-      setIsLoading(true);
-      const file = files[0];
-      const reader = new FileReader();
-      reader.readAsDataURL(file);
-      reader.onloadend = async () => {
-        setImageUrl(reader.result as string);
-        const imageData = reader.result?.toString()?.split(',')[1];
-        if (imageData) {
-          try {
-            const response = await axios.post<{ text: string }>('/api/ocr', { imageData });
-            const product = await ProductService.getSearchProductByTitle(response.data.text);
-            if (product.data.length > 0) {
-              link.to('productItem', `${product.data[4].id}`);
-            } else {
-              alert('Cannot Find Cosmetic');
-              link.to('request');
+  const handleChangeFile = React.useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (files && files.length > 0) {
+        setIsLoading(true);
+        const file = files[0];
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onloadend = async () => {
+          setImageUrl(reader.result as string);
+          const imageData = reader.result?.toString()?.split(',')[1];
+          if (imageData) {
+            try {
+              const response = await axios.post<{ text: string }>('/api/ocr', { imageData });
+              const product = await ProductService.getSearchProductByTitle(response.data.text);
+              if (product.data.length > 0) {
+                link.to('productItem', `${product.data[4].id}`);
+              } else {
+                alert('Cannot Find Cosmetic');
+                link.to('request');
+              }
+              // TODO: text를 가지고 백엔드에 검색해봐야 함
+            } catch (error) {
+              console.error(error);
+            } finally {
+              setIsLoading(false);
             }
-            // TODO: text를 가지고 백엔드에 검색해봐야 함
-          } catch (error) {
-            console.error(error);
-          } finally {
+          } else {
             setIsLoading(false);
           }
-        } else {
-          setIsLoading(false);
-        }
-      };
-    }
-  }, []);
+        };
+      }
+    },
+    [link],
+  );
 
   return (
     <>

--- a/src/pages/skintype/question.tsx
+++ b/src/pages/skintype/question.tsx
@@ -5,8 +5,7 @@ import { useTheme } from '@emotion/react';
 
 import useLink from '@/hooks/useLink';
 import useBaumann from '@/hooks/useBaumann';
-import { Button, Flex, Icon, Text } from '@/components';
-import ProgressBar from '@/components/common/ProgressBar';
+import { Button, Flex, Icon, Text, ProgressBar } from '@/components';
 import type { BaumannQNA, BaumannQuestion } from '@/types/baumann';
 import { getAnswers, saveAnswer, resetAnswers } from '@/utils/baumann';
 


### PR DESCRIPTION
<img width="405" alt="image" src="https://github.com/Egg-sushi/EGGY-Web/assets/42960217/f7dc74d6-11b6-47e5-ba18-9e31bbf3a823">

- [x] 로그인 시, `<HeaderModal />`의 하단 로그인 버튼을 로그아웃 버튼으로 변경
- [x] 로그아웃
- [x] 몇몇 import를 상대 경로로 바꿈