### PR TITLE
Refactor: LONGSTRING, PLAIN 리모델링

### DIFF
--- a/src/components/baumann/BaumannLONGSTRINGType.tsx
+++ b/src/components/baumann/BaumannLONGSTRINGType.tsx
@@ -4,10 +4,12 @@ import styled from '@emotion/styled';
 import Text from '../common/Text';
 import { CircleCheckBox, Flex } from '..';
 import type { BaumannQNA, BaumannQuestion } from '@/types/baumann';
+import { useTheme } from '@emotion/react';
 
 interface Props {
   baumann: {
     id: BaumannQuestion['id'];
+    subStepIndex: number;
     question: BaumannQuestion['question'];
     answers: BaumannQNA['Baumann_Answer'];
   };
@@ -19,10 +21,17 @@ interface Props {
 }
 
 function BaumannLONGSTRINGType({ baumann, activeAnswer, onClickItem }: Props) {
+  const theme = useTheme();
   return (
-    <Flex as={'section'} flexDirection="column" gap={50}>
-      <StyledText variant="body1" dangerouslySetInnerHTML={{ __html: baumann.question }} />
-      <Flex as={'ul'} flexDirection="column" gap={16}>
+    <Flex as={'section'} flexDirection="column" marginBottom={60}>
+      <QuestionIndexText variant="h3" fontColor={theme.colors.gray400}>
+        Q{baumann.subStepIndex}
+      </QuestionIndexText>
+      <QuestionText
+        variant="test-question"
+        dangerouslySetInnerHTML={{ __html: baumann.question }}
+      />
+      <Flex as={'ul'} flexDirection="column" gap={'1rem'}>
         {baumann.answers.map((answer) => (
           <AnswerItem
             as={'li'}
@@ -41,16 +50,21 @@ function BaumannLONGSTRINGType({ baumann, activeAnswer, onClickItem }: Props) {
 
 type StyleAnswerProps = { isActive: boolean };
 const AnswerItem = styled(Flex)<StyleAnswerProps>`
-  border-radius: 10px;
-  padding: 20px;
-  background-color: ${({ theme, isActive }) =>
-    isActive ? theme.colors.blue100 : theme.colors.blue50};
-  cursor: pointer;
   position: relative;
+  background-color: ${({ theme }) => theme.colors.white};
+
+  padding: 1rem 20px;
+  border: ${({ isActive, theme }) =>
+    isActive ? `2px solid ${theme.colors.primary}` : `2px solid ${theme.colors.white}`};
+  border-radius: 3px;
+  box-shadow: 0px 4px 4px
+    ${({ isActive }) => (isActive ? 'rgba(0, 0, 0, 0.1)' : 'rgba(0, 0, 0, 0.15)')};
+
+  cursor: pointer;
 
   &:hover {
-    background-color: ${({ theme, isActive }) =>
-      isActive ? theme.colors.blue150 : theme.colors.blue100};
+    border: ${({ isActive, theme }) =>
+      isActive ? `2px solid ${theme.colors.blue600}` : `2px solid ${theme.colors.blue500}`};
   }
 
   &,
@@ -64,8 +78,28 @@ const AnswerItem = styled(Flex)<StyleAnswerProps>`
   }
 `;
 
+const QuestionText = styled(Text)`
+  white-space: pre-line;
+  height: calc(3em + 3 * 0.35em); // line-height 고려
+  margin-bottom: 1.5rem;
+
+  span {
+    display: inline-block;
+    width: 100%;
+  }
+
+  strong {
+    font-weight: 700;
+  }
+`;
+
+const QuestionIndexText = styled(Text)`
+  margin-bottom: 0.5rem;
+`;
+
 const StyledText = styled(Text)`
   white-space: pre-line;
+  line-height: calc(19 / 16 * 1em);
 
   span {
     display: inline-block;

--- a/src/components/baumann/BaumannPLAINType.tsx
+++ b/src/components/baumann/BaumannPLAINType.tsx
@@ -6,10 +6,12 @@ import Text from '../common/Text';
 import { SkeletonImage } from '../common';
 import FrequencyBar from './FrequencyBar';
 import type { BaumannQNA, BaumannQuestion } from '@/types/baumann';
+import { useTheme } from '@emotion/react';
 
 interface Props {
   baumann: {
     id: BaumannQuestion['id'];
+    subStepIndex: number;
     question: BaumannQuestion['question'];
     imageUrl: BaumannQuestion['imageUrl'];
     answers: BaumannQNA['Baumann_Answer'];
@@ -22,16 +24,23 @@ interface Props {
 }
 
 function BaumannPLAINType({ baumann, activeAnswer, onClickItem }: Props) {
+  const theme = useTheme();
   return (
     <StyledFlex as={'section'} flexDirection="column">
-      <StyledText variant="body1" dangerouslySetInnerHTML={{ __html: baumann.question }} />
+      <QuestionIndexText variant="h3" fontColor={theme.colors.gray400}>
+        Q{baumann.subStepIndex}
+      </QuestionIndexText>
+      <QuestionText
+        variant="test-question"
+        dangerouslySetInnerHTML={{ __html: baumann.question }}
+      />
       <div style={{ width: '100%' }}>
         <SkeletonImage
           height={180}
           src={baumann.imageUrl}
           alt="quiz-thumbnail"
           fill
-          style={{ margin: '30px auto 50px auto' }}
+          style={{ margin: '0 auto 70px auto' }}
         />
       </div>
       <FrequencyBar
@@ -45,10 +54,17 @@ function BaumannPLAINType({ baumann, activeAnswer, onClickItem }: Props) {
 
 const StyledFlex = styled(Flex)`
   padding-bottom: 60px;
+  margin-bottom: 80px;
 `;
 
-const StyledText = styled(Text)`
+const QuestionIndexText = styled(Text)`
+  margin-bottom: 0.5rem;
+`;
+
+const QuestionText = styled(Text)`
   white-space: pre-line;
+  height: calc(3em + 3 * 0.35em); // line-height 고려
+  margin-bottom: 3rem;
 
   span {
     display: inline-block;

--- a/src/components/baumann/BaumannPLAINType.tsx
+++ b/src/components/baumann/BaumannPLAINType.tsx
@@ -26,7 +26,7 @@ interface Props {
 function BaumannPLAINType({ baumann, activeAnswer, onClickItem }: Props) {
   const theme = useTheme();
   return (
-    <StyledFlex as={'section'} flexDirection="column">
+    <Flex as={'section'} flexDirection="column" paddingBottom={60} marginBottom={60}>
       <QuestionIndexText variant="h3" fontColor={theme.colors.gray400}>
         Q{baumann.subStepIndex}
       </QuestionIndexText>
@@ -48,14 +48,9 @@ function BaumannPLAINType({ baumann, activeAnswer, onClickItem }: Props) {
         activeAnswer={activeAnswer}
         onClickItem={onClickItem}
       />
-    </StyledFlex>
+    </Flex>
   );
 }
-
-const StyledFlex = styled(Flex)`
-  padding-bottom: 60px;
-  margin-bottom: 80px;
-`;
 
 const QuestionIndexText = styled(Text)`
   margin-bottom: 0.5rem;

--- a/src/components/baumann/BaumannPLAINType.tsx
+++ b/src/components/baumann/BaumannPLAINType.tsx
@@ -39,7 +39,7 @@ function BaumannPLAINType({ baumann, activeAnswer, onClickItem }: Props) {
           height={180}
           src={baumann.imageUrl}
           alt="quiz-thumbnail"
-          fill
+          objectFit="contain"
           style={{ margin: '0 auto 70px auto' }}
         />
       </div>

--- a/src/components/baumann/FrequencyBar.tsx
+++ b/src/components/baumann/FrequencyBar.tsx
@@ -27,10 +27,10 @@ function FrequencyBar({ answers, activeAnswer, onClickItem }: Props) {
             <Item key={answer.id} onClick={(e) => onClickItem(answer, e)}>
               <Circle key={answer.id} isActive={isActive} />
               <CircleLabel
-                variant="body2"
+                variant="body3"
                 fontColor={isActive ? theme.colors.primary : theme.colors.gray500}
-                weight={isActive ? 800 : 400}
                 align="center"
+                weight={isActive ? 700 : 400}
                 dangerouslySetInnerHTML={{ __html: answer.answer }}
               />
             </Item>
@@ -42,14 +42,14 @@ function FrequencyBar({ answers, activeAnswer, onClickItem }: Props) {
 }
 
 const Wrapper = styled.div`
-  width: calc(100% - 30px);
-  padding-left: 15px;
+  width: calc(100% - 72px);
+  padding-left: 36px;
   position: relative;
 `;
 
 const GrayBar = styled.span`
   content: '';
-  width: 100%;
+  width: calc(100% - 42px);
   height: 1px;
   position: absolute;
   background-color: ${({ theme }) => theme.colors.gray300};
@@ -64,25 +64,28 @@ const Item = styled.li`
 type IsActive = { isActive: boolean };
 const Circle = styled.span<IsActive>`
   position: absolute;
-  top: -15px;
+  top: -20px;
   transform: translateX(-50%);
   content: '';
-  width: 30px;
-  height: 30px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   box-sizing: border-box;
   background-color: ${({ theme }) => theme.colors.white};
   border: ${({ isActive }) => !isActive && '1px solid'};
   border-color: ${({ theme }) => theme.colors.gray300};
-  box-shadow: ${({ isActive, theme }) => isActive && `inset 0 0 0 8px ${theme.colors.primary}`};
+  box-shadow: ${({ isActive, theme }) => isActive && `inset 0 0 0 10px ${theme.colors.primary}`};
   transition: all 0.1s ease-in;
 `;
 
 const CircleLabel = styled(Text)`
   position: absolute;
-  top: 20px;
+  top: 28px;
   transform: translateX(-50%);
   transition: all 0.1s ease-in;
+
+  width: max-content;
+  max-width: 4.5rem;
 `;
 
 export default FrequencyBar;

--- a/src/components/baumann/ProgressBar.tsx
+++ b/src/components/baumann/ProgressBar.tsx
@@ -111,7 +111,7 @@ const Step = ({ currentStepIndex, progressSubStep, stepIndex, title, iconType }:
 
 const Wrapper = styled.div`
   width: 100%;
-  padding: 8px 20px;
+  padding: 16px 20px;
   box-sizing: border-box;
 `;
 

--- a/src/components/common/SkeletonImage.tsx
+++ b/src/components/common/SkeletonImage.tsx
@@ -31,7 +31,7 @@ type FillProps = {
   src: string;
   alt: string;
   height: number;
-  objectFit: React.CSSProperties['objectFit'];
+  objectFit?: React.CSSProperties['objectFit'];
   style?: React.CSSProperties;
   priority?: boolean;
   placeholder?: 'blur' | 'empty';
@@ -83,9 +83,9 @@ function SkeletonImage(props: Props) {
         priority={priority}
         src={src}
         alt={alt}
-        fill={Boolean(objectFit)}
+        fill={objectFit !== 'none'}
         width={width}
-        height={Boolean(objectFit) ? undefined : height}
+        height={objectFit !== 'none' ? undefined : height}
         placeholder={placeholder}
         unoptimized={unoptimized}
       />

--- a/src/components/common/SkeletonImage.tsx
+++ b/src/components/common/SkeletonImage.tsx
@@ -98,6 +98,10 @@ const Wrapper = styled.div<StyleProps>`
   position: relative;
   width: ${({ fill, width }) => (fill ? '100%' : typeof width === 'number' ? `${width}px` : width)};
   height: ${({ height }) => (typeof height === 'number' ? `${height}px` : height)};
+
+  img {
+    object-fit: contain;
+  }
 `;
 
 const LeftToRight = keyframes`

--- a/src/components/common/SkeletonImage.tsx
+++ b/src/components/common/SkeletonImage.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Image from 'next/image';
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/react';
-import { XOR } from '@/utils';
 
 const EVENT_IMAGE_LOAD = 'event_image_load';
 const THRESHOLD = 0.5;
@@ -16,29 +15,17 @@ const onIntersection = (entries: IntersectionObserverEntry[], io: IntersectionOb
   });
 };
 
-type WidthProps = {
+type Props = {
   src: string;
   alt: string;
-  width: number;
-  height: number;
-  style?: React.CSSProperties;
-  priority?: boolean;
-  placeholder?: 'blur' | 'empty';
-  unoptimized?: boolean;
-};
-
-type FillProps = {
-  src: string;
-  alt: string;
-  height: number;
+  width?: number;
+  height?: number;
   objectFit?: React.CSSProperties['objectFit'];
   style?: React.CSSProperties;
   priority?: boolean;
   placeholder?: 'blur' | 'empty';
   unoptimized?: boolean;
 };
-
-type Props = XOR<WidthProps, FillProps>;
 
 function SkeletonImage(props: Props) {
   const imageRef = React.useRef<HTMLImageElement | null>(null);
@@ -48,7 +35,7 @@ function SkeletonImage(props: Props) {
     src,
     alt,
     style,
-    objectFit = 'none',
+    objectFit = 'fill',
     width,
     height,
     priority,
@@ -56,6 +43,8 @@ function SkeletonImage(props: Props) {
     unoptimized = false,
     ...restProps
   } = props;
+
+  const fill = !Boolean(width) || !Boolean(height);
 
   React.useEffect(() => {
     const handleLoadImage = () => setIsLoaded(true);
@@ -80,16 +69,18 @@ function SkeletonImage(props: Props) {
     <Wrapper width={width} height={height} style={style} objectFit={objectFit} {...restProps}>
       <Image
         ref={imageRef}
-        priority={priority}
         src={src}
         alt={alt}
-        fill={objectFit !== 'none'}
-        width={width}
-        height={objectFit !== 'none' ? undefined : height}
+        fill={fill}
+        width={fill ? undefined : width}
+        height={fill ? undefined : height}
+        className={fill ? 'fill' : 'non-fill'}
+        priority={priority}
         placeholder={placeholder}
         unoptimized={unoptimized}
       />
-      {!isLoaded && <SkeletonBox width={width} height={height} />}
+
+      {!isLoaded && <SkeletonBox />}
     </Wrapper>
   );
 }
@@ -97,12 +88,17 @@ function SkeletonImage(props: Props) {
 type StyleProps = Pick<Props, 'width' | 'height' | 'objectFit'>;
 const Wrapper = styled.div<StyleProps>`
   position: relative;
-  width: ${({ objectFit, width }) =>
-    objectFit === 'fill' ? '100%' : typeof width === 'number' ? `${width}px` : width};
+  width: ${({ width }) => (typeof width === 'number' ? `${width}px` : width)};
   height: ${({ height }) => (typeof height === 'number' ? `${height}px` : height)};
 
   img {
     object-fit: ${({ objectFit }) => objectFit};
+  }
+
+  img.fill {
+    position: relative !important;
+    width: 100% !important;
+    height: ${({ height }) => (height ? '100%' : 'auto')} !important;
   }
 `;
 
@@ -115,7 +111,7 @@ const LeftToRight = keyframes`
   }
 `;
 
-const SkeletonBox = styled.div<StyleProps>`
+const SkeletonBox = styled.div`
   position: absolute;
   width: 100%;
   height: 100%;

--- a/src/components/common/SkeletonImage.tsx
+++ b/src/components/common/SkeletonImage.tsx
@@ -31,12 +31,13 @@ type FillProps = {
   src: string;
   alt: string;
   height: number;
-  fill: boolean;
+  objectFit: React.CSSProperties['objectFit'];
   style?: React.CSSProperties;
   priority?: boolean;
   placeholder?: 'blur' | 'empty';
   unoptimized?: boolean;
 };
+
 type Props = XOR<WidthProps, FillProps>;
 
 function SkeletonImage(props: Props) {
@@ -47,7 +48,7 @@ function SkeletonImage(props: Props) {
     src,
     alt,
     style,
-    fill = false,
+    objectFit = 'none',
     width,
     height,
     priority,
@@ -76,15 +77,15 @@ function SkeletonImage(props: Props) {
   }, [imageRef]);
 
   return (
-    <Wrapper width={width} height={height} style={style} {...restProps}>
+    <Wrapper width={width} height={height} style={style} objectFit={objectFit} {...restProps}>
       <Image
         ref={imageRef}
         priority={priority}
         src={src}
         alt={alt}
-        fill={fill}
+        fill={Boolean(objectFit)}
         width={width}
-        height={fill ? undefined : height}
+        height={Boolean(objectFit) ? undefined : height}
         placeholder={placeholder}
         unoptimized={unoptimized}
       />
@@ -93,14 +94,15 @@ function SkeletonImage(props: Props) {
   );
 }
 
-type StyleProps = Pick<Props, 'width' | 'height' | 'fill'>;
+type StyleProps = Pick<Props, 'width' | 'height' | 'objectFit'>;
 const Wrapper = styled.div<StyleProps>`
   position: relative;
-  width: ${({ fill, width }) => (fill ? '100%' : typeof width === 'number' ? `${width}px` : width)};
+  width: ${({ objectFit, width }) =>
+    objectFit === 'fill' ? '100%' : typeof width === 'number' ? `${width}px` : width};
   height: ${({ height }) => (typeof height === 'number' ? `${height}px` : height)};
 
   img {
-    object-fit: contain;
+    object-fit: ${({ objectFit }) => objectFit};
   }
 `;
 

--- a/src/components/product/ProductItem.tsx
+++ b/src/components/product/ProductItem.tsx
@@ -36,7 +36,7 @@ function ProductItem({ product, like = false, onClickLike }: Props) {
         <SkeletonImage
           src={product.imageUrl}
           alt="product-thumbnail"
-          fill
+          objectFit="contain"
           height={324}
           unoptimized
           style={{

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -20,7 +20,12 @@ export default function LoginPage() {
       <Header />
       <Content>
         <GoogleLoginButton onClick={handleClickGoogleLogin}>
-          <SkeletonImage src="/GoogleLogin.png" fill height={(92 / 5) * 3} alt="google-login" />
+          <SkeletonImage
+            src="/GoogleLogin.png"
+            objectFit="contain"
+            height={(92 / 5) * 3}
+            alt="google-login"
+          />
         </GoogleLoginButton>
       </Content>
     </>

--- a/src/pages/skintype/question.tsx
+++ b/src/pages/skintype/question.tsx
@@ -113,6 +113,7 @@ export default function SkinTypeTest() {
         <BaumannQNAComponent
           baumann={{
             id: currentQna.id,
+            subStepIndex: currentSubStepIndex,
             question: currentQna.question,
             answers: currentQna.Baumann_Answer,
             imageUrl: currentQna?.imageUrl,
@@ -155,13 +156,12 @@ const StyledProgressBar = styled(ProgressBar)`
 `;
 
 const Content = styled.div<{ questionType: BaumannQuestion['questionType'] }>`
-  padding-top: 40px;
+  padding-top: 20px;
   padding-inline: 20px;
   height: calc(100% - 160px);
   background-color: ${({ theme, questionType }) => questionType === 'PLAIN' && theme.colors.blue50};
 `;
 
 const BottomPosition = styled.div`
-  padding: 50px 0;
-  bottom: 50px;
+  bottom: 80px;
 `;

--- a/src/pages/skintype/question.tsx
+++ b/src/pages/skintype/question.tsx
@@ -102,7 +102,6 @@ export default function SkinTypeTest() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <TopRef ref={topRef} />
       <StyledProgressBar
         currentStepIndex={currentStepIndex}
         title={currentQna.type}
@@ -110,6 +109,7 @@ export default function SkinTypeTest() {
         totalSubStepNum={totalSubStepNum}
       />
       <Content questionType={qnaType}>
+        <TopRef ref={topRef} />
         <BaumannQNAComponent
           baumann={{
             id: currentQna.id,
@@ -121,30 +121,31 @@ export default function SkinTypeTest() {
           activeAnswer={activeAnswer}
           onClickItem={handleClickAnswerItem}
         />
-        <BottomPosition>
-          <Flex justifyContent="space-between" gap="16px">
-            <Button
-              variant="outlined"
-              Icon={<Icon fill={theme.colors.primary} type="leftArrow" width={14} height={14} />}
-              onClick={handleClickPrev}
-            >
-              <Text variant="body2" fontColor={theme.colors.primary}>
-                Prev
-              </Text>
-            </Button>
-            <Button
-              variant="filled"
-              Icon={<Icon type="rightArrow" fill={theme.colors.white} width={14} height={14} />}
-              onClick={handleClickNext}
-              iconPosition="end"
-            >
-              <Text variant="body2" fontColor={theme.colors.white}>
-                {isLastQna ? 'End' : 'Next'}
-              </Text>
-            </Button>
-          </Flex>
-        </BottomPosition>
       </Content>
+
+      <BottomPosition>
+        <Flex justifyContent="space-between" gap="16px">
+          <Button
+            variant="outlined"
+            Icon={<Icon fill={theme.colors.primary} type="leftArrow" width={14} height={14} />}
+            onClick={handleClickPrev}
+          >
+            <Text variant="body2" fontColor={theme.colors.primary}>
+              Prev
+            </Text>
+          </Button>
+          <Button
+            variant="filled"
+            Icon={<Icon type="rightArrow" fill={theme.colors.white} width={14} height={14} />}
+            onClick={handleClickNext}
+            iconPosition="end"
+          >
+            <Text variant="body2" fontColor={theme.colors.white}>
+              {isLastQna ? 'End' : 'Next'}
+            </Text>
+          </Button>
+        </Flex>
+      </BottomPosition>
     </>
   );
 }
@@ -152,17 +153,28 @@ export default function SkinTypeTest() {
 const TopRef = styled.div``;
 
 const StyledProgressBar = styled(ProgressBar)`
+  position: fixed;
+  top: 0;
   padding: 1rem 0;
+  background-color: ${({ theme }) => theme.colors.white};
 `;
 
 const Content = styled.div<{ questionType: BaumannQuestion['questionType'] }>`
-  padding-top: 20px;
+  padding: 140px 20px 90px;
   padding-inline: 20px;
-  height: calc(100% - 160px);
+  overflow-y: scroll;
+  box-sizing: border-box;
+  height: 100%;
   background-color: ${({ theme, questionType }) =>
     questionType === 'PLAIN' ? theme.colors.blue50 : theme.colors.gray50};
 `;
 
 const BottomPosition = styled.div`
-  bottom: 80px;
+  position: fixed;
+  width: 100%;
+  box-sizing: border-box;
+  bottom: 0;
+  padding: 25px 20px;
+  height: 140px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #ffffff 44.29%);
 `;

--- a/src/pages/skintype/question.tsx
+++ b/src/pages/skintype/question.tsx
@@ -159,7 +159,8 @@ const Content = styled.div<{ questionType: BaumannQuestion['questionType'] }>`
   padding-top: 20px;
   padding-inline: 20px;
   height: calc(100% - 160px);
-  background-color: ${({ theme, questionType }) => questionType === 'PLAIN' && theme.colors.blue50};
+  background-color: ${({ theme, questionType }) =>
+    questionType === 'PLAIN' ? theme.colors.blue50 : theme.colors.gray50};
 `;
 
 const BottomPosition = styled.div`

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -2,6 +2,7 @@ export const colors = {
   // gray scale
   black: '#000000',
   white: '#ffffff',
+  gray50: '#fcfcfc',
   gray100: '#edf0f3',
   gray200: '#c5c8cb',
   gray300: '#9da0a3',

--- a/src/theme/fonts.ts
+++ b/src/theme/fonts.ts
@@ -85,4 +85,9 @@ export const fonts = {
     letter-spacing: -0.018em;
     line-height: 1.6;
   `,
+  /** font-size: 20px */
+  'test-question': css`
+    font-size: 1.25rem;
+    line-height: 1.35;
+  `,
 };


### PR DESCRIPTION
- [x] PLAIN Figma와 통일
- [x] LONGSTRING Figma와 통일
- [x] `fonts['test-question']` 추가
- [x] `colors['gray50']`추가 

<img width="399" alt="image" src="https://github.com/Egg-sushi/EGGY-Web/assets/42960217/d1268e78-bc3d-4e2e-bfd5-a309589e6808">

<img width="398" alt="image" src="https://github.com/Egg-sushi/EGGY-Web/assets/42960217/19100633-42c2-4be4-af14-60224b9774f8">


TODO
- [ ] PLAIN, LONGSTRING, GRID 모두에 적용될 수 있는 버튼 위치 가이드라인 요구
- [ ] ~PLAIN에 있는 이미지들 크기 통일 요구 (Figma 상으로 Width 100% 짜리 직사각형이 Group 내에 있어야함)~
  - [x] `object-fit`으로 해결 완료